### PR TITLE
chore: leverage concurrency for ci checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,20 +16,11 @@ name: CI
 
 on: [push, pull_request]
 
-jobs:
-  skip_check:
-    name: Skip Check
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          cancel_others: 'true'
-          skip_after_successful_duplicate: 'true'
-          concurrent_skipping: 'same_content_newer'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   test:
     name: Node.js v${{ matrix.nodejs }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This will cancel any inflight action runs for this workflow + ref, without the need for a step to run that costs you run mins.

- `refs/heads/<branch_name>`
- `refs/pull/<pr_number>/merge`